### PR TITLE
fixed a warning about importing the console

### DIFF
--- a/lib/chk.js
+++ b/lib/chk.js
@@ -3,15 +3,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.isNodeJs = void 0;
 function isNodeJs() {
     try {
-        require('console');
-        // @ts-ignore
-        if (console._stdout && console._stderr) {
-            return true;
-        }
+		if (
+			typeof process !== 'undefined' && 
+			process.release.name.search(/node|io.js/) !== -1
+		) {
+			return true;
+      }
+		return false;
     }
     catch (e) {
     }
-    return false;
 }
 exports.isNodeJs = isNodeJs;
 exports.default = isNodeJs;

--- a/lib/chk.ts
+++ b/lib/chk.ts
@@ -3,20 +3,18 @@ export function isNodeJs()
 {
 	try
 	{
-		require('console');
-
-		// @ts-ignore
-		if (console._stdout && console._stderr)
-		{
-			return true
-		}
+		if (
+			typeof process !== 'undefined' && 
+			process.release.name.search(/node|io.js/) !== -1
+		) {
+			return true;
+      }
+		return false;
 	}
 	catch (e)
 	{
 
 	}
-
-	return false
 }
 
 export default isNodeJs


### PR DESCRIPTION
Hi! When building a frontend application, you get a warning about not being able to import console.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>